### PR TITLE
Upgrade coc, including some statements from Contributor Covenant v2.0

### DIFF
--- a/content/coc.md
+++ b/content/coc.md
@@ -120,7 +120,7 @@ This Code of Conduct is adapted from the [Contributor Covenant][contributor-cove
 version 2.0, available at
 https://www.contributor-covenant.org/version/2/0/code_of_conduct.html and portions of [Slack Developer Community Code of Conduct][slack-coc]
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
+Community Impact Guidelines were inspired by [Mozilla’s code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
 
 [contributor-covenant]: https://www.contributor-covenant.org

--- a/content/coc.md
+++ b/content/coc.md
@@ -2,52 +2,111 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as pledge to
-making participation in our project and our community a harassment-free
-experience for everyone, regardless of age, body size, disability, ethnicity,
-gender identity and expression, level of experience, education, socio-economic
-status, nationality, personal appearance, race, religion, or sexual identity
+We as members, contributors, and admins pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
 and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+The following statements apply to all means of communication and shapes, i.e. text messages, reactions, calls, video calls...
 
 ## Expected Behaviour
 
 * Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
 * Showing empathy towards other community members
 
 ## Unacceptable Behavior
 
 * Conduct or speech which might be considered sexist, racist, homophobic, 
-  transphobic,   ableist or otherwise discriminatory or offensive in nature.
+  transphobic, ableist or otherwise discriminatory or offensive in nature.
   - Do not use unwelcome, suggestive, derogatory or inappropriate nicknames or terms.
-  - Do not show disrespect towards others. (Jokes, innuendo, dismissive attitudes.)
+  - Do not show disrespect towards others. (Jokes, innuendo, dismissive attitudes)
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment. Please read the [Citizen Code of Conduct][citizen-coc]
   for how we interpret harassment.
 * Publishing others' private information, such as a physical or electronic
   address, without explicit permission
 * Violence, threats of violence or violent language.
+* Other conduct which could reasonably be considered inappropriate in a  professional setting
 
-## Our Responsibilities
+## Enforcement Responsibilities
 
-Community admins are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Community admins are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Also have the right and responsibility to remove, edit, or reject comments and
+Community admins have the right and responsibility to remove, edit, or reject comments and
 other contributions that are not aligned to this Code of Conduct, or to ban
 temporarily or permanently any member for other behaviors that they deem
 inappropriate, threatening, offensive, or harmful.
 
 ## Enforcement
 
-If you are the subject of, or witness to any violations of this Code of Conduct, 
-PLEASE contact the project team at bcnengineers at gmail dot com and we will help you.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community admins responsible for enforcement at bcnengineers at gmail dot com and we will help you.
 
-The admin team is obligated to maintain confidentiality with regard to the reporter 
-of an incident.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community admins are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community admins will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community admins, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
 
 ## Language
 
@@ -57,8 +116,12 @@ We also know that a lot of members use English as a way to communicate, as it's 
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][contributor-covenant], 
-with  version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html and portions of [Slack Developer Community Code of Conduct][slack-coc]
+This Code of Conduct is adapted from the [Contributor Covenant][contributor-covenant],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html and portions of [Slack Developer Community Code of Conduct][slack-coc]
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
 
 [contributor-covenant]: https://www.contributor-covenant.org
 [citizen-coc]: http://citizencodeofconduct.org


### PR DESCRIPTION
I added some points of the improved version of the Contributor Covenant COC (https://www.contributor-covenant.org/version/2/0/code_of_conduct/). 
Also added a clarification about the scope and means of communications implied:

> The following statements apply to all means of communication and shapes, i.e. text messages, reactions, calls, video calls...