### PR TITLE
Remove manual copyright footer

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,6 @@ languageCode = "en-us"
 title = "BCN Engineering"
 description = "By engineers, for engineers."
 theme = "chunky-poster"
-copyright = "Copyright © 2020, BcnEng; all rights reserved."
 paginate = 2
 enableInlineShortcodes = true
 footnoteReturnLinkContents = "^"


### PR DESCRIPTION
This PR removes the manual copyright footer line in favor of an automated one.

Before:

![image](https://user-images.githubusercontent.com/1083296/108047054-a51b0d80-7045-11eb-806e-7991032386ae.png)


After:

![image](https://user-images.githubusercontent.com/1083296/108047036-a0565980-7045-11eb-983b-144d33699828.png)
