### PR TITLE
docs: replace bcnengineers@gmail.com by contact@bcneng.org

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -53,7 +53,7 @@ author = "authors"
     twitter = "https://twitter.com/bcn_eng"
     linkedin = "https://www.linkedin.com/company/bcneng/"
     github = "https://github.com/bcneng"
-    email = "bcnengineers@gmail.com"
+    email = "contact@bcneng.org"
 
   [params.prismJS]
     enable = true

--- a/content/coc.md
+++ b/content/coc.md
@@ -55,7 +55,7 @@ inappropriate, threatening, offensive, or harmful.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community admins responsible for enforcement at bcnengineers at gmail dot com and we will help you.
+reported to the community admins responsible for enforcement at contact@bcneng.org and we will help you.
 
 All complaints will be reviewed and investigated promptly and fairly.
 


### PR DESCRIPTION
We use now Gsuite for non-profits so we created a new email account `contact@bcneng.org` that replaces the `bcnengineers@gmail.com`. Emails are now being redirected to `contact@bcneng.org`.