### PR TITLE
Re-style contributors iframe

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -36,7 +36,10 @@
                     <button type="button" class="btn btn-dark">DONATE <i class="open-collective"></i></button>
                 </a>
             </div>
-            <script src='https://opencollective.com/bcneng/banner.js?style={"a":{"color":"black", "fontFamily":"sans-serif"},"h2":{"fontFamily":"sans-serif","fontWeight":"bold","fontSize":"1.2em"}}'></script>
+
+            <h3>Contributors</h3>
+			Thanks to these community members for helping us.
+			<script src='https://opencollective.com/bcneng/banner.js?style={"a":{"display":"none"}, "h2":{"display":"none"}}'></script>
             <h3>Sponsors</h3>
             <p>Thanks to these organizations for helping us.</p>
             <div class="sponsor-logos">

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -106,15 +106,15 @@ li {
 .opencollective-banner {
   display: flex;
   justify-content: left;
-  margin: 10px 0 0 -10px;
+  margin: -10px 0 -100px 0;
 }
 .opencollective-banner iframe {
-  width: auto;
+  width: 100%;
 }
 @media (max-width: 575px) {
   .opencollective-banner {
     display: block;
-    margin: 0;
+    margin: 0 0 -50px 0;
   }
   .opencollective-banner iframe {
     width: 100%;


### PR DESCRIPTION
I did not like how the default style for the opencollective iframe for contributors looked on desktop.

## before

<img width="1439" alt="CleanShot 2023-03-12 at 20 55 49@2x" src="https://user-images.githubusercontent.com/349328/224570061-fe9aad03-fff3-4497-afec-c14956960730.png">

## after

<img width="1440" alt="CleanShot 2023-03-12 at 20 55 16@2x" src="https://user-images.githubusercontent.com/349328/224570057-77309476-c19a-48bd-a5c3-a19336d3294a.png">

