### PR TITLE
Ground content removals in the CoC and document the moderation process

### DIFF
--- a/content/netiquette.md
+++ b/content/netiquette.md
@@ -3,11 +3,11 @@
 Welcome to BcnEng's netiquette.
 
 This document can change over time. The administrators will publish its updates
-on the #general channel. To join this community you agree to it's contents. If
+on the #general channel. To join this community you agree to its contents. If
 you don't, you must logout and delete your account.
 
 You can propose improvements to this document by communicating them in the
-`#ask-staff` channel or [opening a pull request](https://github.com/bcneng/website/edit/master/content/netiquette.md).
+`#ask-staff` channel or [opening a pull request](https://github.com/bcneng/website/edit/main/content/netiquette.md).
 
 ## Definition
 
@@ -17,11 +17,13 @@ From [wikipedia](https://en.wikipedia.org/wiki/Etiquette_in_technology#Netiquett
 
 ## Conventions
 
-Here you will find a set of basic conventions that we find useful. They are part of the set of behaviours that the community users expect from each other. Please make sure you understand all of them. Remember that you can write any question or ask for advice in our specific Slack channel #coc-netiquette
+Here you will find a set of basic conventions that we find useful. They are part of the set of behaviours that the community users expect from each other. Please make sure you understand all of them. Remember that you can write any question or ask for advice in the `#ask-staff` channel.
 
 ### Behaviour
 
 Be respectful with your colleagues and follow the [Code of Conduct](/coc/) rules.
+
+This is a professional community. If you are unsure whether something is appropriate, or you feel it needs a "just joking" disclaimer, don't post it. The burden of judgment is on the poster, not the moderators.
 
 ### Accounts
 
@@ -54,9 +56,13 @@ The administrators reserve the right to:
 
 #### Moderation
 
+The administrators are volunteers moderating on their own time.
+
 - When content is removed, an administrator will tell the author privately which rule motivated it.
-- If you disagree with a moderation decision, raise it in `#ask-staff` or by DM to an admin. Don't relitigate it in the affected channel.
+- If you disagree with a moderation decision, you can raise it once in `#ask-staff`. Once the administrators respond, the decision is final. Don't relitigate it in the affected channel.
 - Humor at the expense of a group of people may be removed even if members of that group don't find it offensive. The bar is whether it keeps the community welcoming for everyone, not whether a particular person minds.
+- These guidelines describe intent, not an exhaustive list. "It's not explicitly forbidden" is not a defense, and arguing technicalities with the administrators is itself considered disruptive.
+- Behavior that repeatedly generates moderation work may be treated as a violation on its own, even if no single post crosses a line.
 - Repeated removals of a member's content will escalate through the Code of Conduct's [Enforcement Guidelines](/coc/#enforcement-guidelines), up to a ban.
 
 #### Hiring inquiries and other service offerings

--- a/content/netiquette.md
+++ b/content/netiquette.md
@@ -49,8 +49,15 @@ We will consider spam to be:
 
 The administrators reserve the right to:
 
-- Remove abusive and/or spam comments.
+- Remove any content that, in their judgment, goes against the [Code of Conduct](/coc/) or these guidelines. This is a judgment call about impact on the community, not an accusation of bad intent by the author.
 - Remove link previews for better readability.
+
+#### Moderation
+
+- When content is removed, an administrator will tell the author privately which rule motivated it.
+- If you disagree with a moderation decision, raise it in `#ask-staff` or by DM to an admin. Don't relitigate it in the affected channel.
+- Humor at the expense of a group of people may be removed even if members of that group don't find it offensive. The bar is whether it keeps the community welcoming for everyone, not whether a particular person minds.
+- Repeated removals of a member's content will escalate through the Code of Conduct's [Enforcement Guidelines](/coc/#enforcement-guidelines), up to a ban.
 
 #### Hiring inquiries and other service offerings
 


### PR DESCRIPTION
A recent moderation case (a meme joking about a group of people) surfaced two gaps: the netiquette only authorized removing abusive or spam comments, so the removal had no documented basis, and nothing described what happens after content is removed, which is where the friction happened. Since admins are unpaid volunteers, the rules should also reduce how often moderation is needed, not just describe it.

This broadens the removal right to any content that conflicts with the Code of Conduct and adds a Moderation section: private notification of which rule motivated a removal, a single appeal in #ask-staff after which the decision is final, group-targeted humor judged by community-wide impact rather than whether the targeted group minds, a no-rules-lawyering clause, and escalation through the CoC enforcement ladder for repeated removals or for behavior that repeatedly generates moderation work. It also puts the burden of judgment on the poster (when in doubt, don't post), consolidates the meta channel to #ask-staff, and fixes an its/it's typo and a stale master branch link. No numeric strike limit on purpose: the ladder is the backstop and admins keep judgment over pacing.